### PR TITLE
Update(grid): Enable bulma grid helper classes

### DIFF
--- a/src/scss/_grid.scss
+++ b/src/scss/_grid.scss
@@ -3,11 +3,13 @@
 
 $tablet: 768px;
 @import "~bulma/sass/utilities/all";
+@import "~bulma/sass/base/helpers";
 @import "~bulma/sass/grid/all";
 
 .columns {
   margin-left: $grid-spacing * -1;
   margin-right: $grid-spacing * -1;
+  margin-top: $grid-spacing * -1;
 
   &_center-horizontal {
     justify-content: center;


### PR DESCRIPTION
Who: @lelith

What / Why: is enables the usage of bulma helper classes like is-hidden-mobile etc. 
also sets the margin-top of columns to the actual grid spacing, was -0.75em before which caused some layout glitches.